### PR TITLE
CW log group management added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Operational Review Tool (version: 1.1.1)
+# Serverless Operational Review Tool (version: 1.1.1)
 
 This tool has been created to help evaluate **AWS Serverless services** in bulk and to automatically generate a full review report which aims to assist in customer resource analysis.
 

--- a/template.yaml
+++ b/template.yaml
@@ -1,4 +1,4 @@
-# Serverless Ops Review 
+# Serverless Ops Review
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
@@ -98,6 +98,12 @@ Resources:
                 - 'support:DescribeTrustedAdvisorCheckResult'
               Resource: '*'
 
+  GenerateReportFunctionAllLogGroup:
+    Condition: FunctionsNotSet
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${GenerateReportFunctionAll}
+      RetentionInDays: 14 
 
 #############################################################################################################################################
 
@@ -157,6 +163,13 @@ Resources:
                 status-details: 
                   status: [CREATE_COMPLETE, UPDATE_COMPLETE]
 
+  FunctionSelectedLogGroup:
+    Condition: FunctionsSet
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${FunctionSelected}
+      RetentionInDays: 14
+
   GenerateReportFunctionSelected:
     Condition: FunctionsSet
     Type: AWS::Serverless::Function
@@ -197,6 +210,12 @@ Resources:
                 - 'support:DescribeTrustedAdvisorCheckResult'
               Resource: '*'
 
+  GenerateReportFunctionSelectedLogGroup:
+    Condition: FunctionsSet
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${GenerateReportFunctionSelected}
+      RetentionInDays: 14
 #############################################################################################################################################
   
             
@@ -227,6 +246,12 @@ Resources:
                 - 'ssm:PutParameter'
                 - 'ssm:GetParameter'
               Resource: '*'
+
+  GeneratePresignsLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${GeneratePresigns}
+      RetentionInDays: 14
 
   SfnLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
*Description of changes:*
CW log groups of Lambda functions added to the template so they are removed once the tool is deleted from AWS account, without residue log groups.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
